### PR TITLE
WIP: Create Opt-out form page

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -21,6 +21,7 @@
             <li><a href="https://help.prx.org/">Help</a></li>
             <li><a href="http://status.prx.org/">Status</a></li>
             <li><a href="https://exchange.prx.org/terms-of-use">Terms</a></li>
+            <li><a href="/opt-out">Opt-out</a></li>
             <li><a href="/attribution">Attribution</a></li>
             <li><a href="https://exchange.prx.org/privacy-policy">Privacy</a></li>
           </ul>

--- a/pages/opt-out.md
+++ b/pages/opt-out.md
@@ -1,0 +1,36 @@
+---
+layout: page
+title: Opt Out of Programmatic Ads
+description: You may opt out of all programmatic advertising served by any show hosted on Dovetail.
+permalink: /opt-out/
+image: /assets/img/og-image.jpg
+---
+<header class="post-header bg-black-diagonal text-white lede hero px-5 pb-5 m-0">
+  <div class="hero-content container col-xxl-8">
+    <div class="hero-content-inner">
+      <h1 class="display-5 post-title p-name" itemprop="name headline">Opt Out of Programmatic Exchanges</h1>
+    </div>
+  </div>
+</header>
+
+<div class="p-5 bg-gray-x">
+  <div class="container col-xxl-8">
+
+  <div class="post-content">
+    <p>You may opt out of all programmatic advertising served by any show hosted on Dovetail by filling out the form below. We will verify your request using the provided information.</p>
+    <form name="opt_out_form" accept-charset="UTF-8" action="#" method="POST">
+      <div class="form-group">
+        <label for="inputEmail">Email address*</label>
+        <input type="email" class="form-control" id="inputEmail" name="inputEmail" aria-describedby="emailHelp" placeholder="Enter email" required>
+        <small class="form-text">Your email is required for verification purposes and, if necessary, to communicate with you about your opt-out. We'll never share your email with anyone else.</small>
+      </div>
+      <div class="form-group">
+        <label for="textIP">IP Address</label>
+        <input type="text" class="form-control" id="textIP" name="textIP" aria-describedby="textIP" placeholder="Enter your IP Address">
+        <small class="form-text"><a href="https://whatismyipaddress.com/" target="_blank">Look up your IP here</a>. Once you submit the form, the IP address will be indefinitely blocked. We'll never share your IP with anyone else. </small>
+      </div>
+      <button type="submit" class="btn btn-primary">Submit</button>
+    </form>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
Closes prx/augury.prx.org#1064

- This is a really basic form to capture opt outs
- Instead of displaying an IP address for the user, I link to whatismyipaddress.com (I feel more comfortable NOT displaying it on our website) where they can grab it quickly.
- Help text galore. Could use a review

Todo
- [ ] Needs a backend

To Review
-[ ] `bundle install`
-[ ] `bundle exec jekyll server`
-[ ] Go to [localhost:4000/opt-out](http://localhost:4000/opt-out) to review the page
