### PR TITLE
fix(config): add url variable to config

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,4 +1,5 @@
 title: Dovetail from PRX
+url: "https://dovetail.prx.org" # the base hostname & protocol for your site
 
 author:
   name: PRX


### PR DESCRIPTION
Sitemap is rendering with relative URLs. 

[The Sitemaps Gem](https://github.com/jekyll/jekyll-sitemap) requires a `URL variable` 

Adding.