### PR TITLE
WIP: DEMO: Jekyll admin example

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem "kramdown-parser-gfm" if ENV["JEKYLL_VERSION"] == "~> 3.9"
 gem "webrick"
 
 group :jekyll_plugins do
+  gem 'jekyll-admin'
   gem "jekyll-sitemap"
   gem "jekyll-feed"
   gem "jekyll-seo-tag"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,6 +38,10 @@ GEM
       rouge (~> 3.0)
       safe_yaml (~> 1.0)
       terminal-table (~> 2.0)
+    jekyll-admin (0.11.1)
+      jekyll (>= 3.7, < 5.0)
+      sinatra (>= 1.4)
+      sinatra-contrib (>= 1.4)
     jekyll-feed (0.16.0)
       jekyll (>= 3.7, < 5.0)
     jekyll-sass-converter (2.2.0)
@@ -67,10 +71,16 @@ GEM
     mime-types (3.4.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2022.0105)
+    multi_json (1.15.0)
+    mustermann (3.0.0)
+      ruby2_keywords (~> 0.0.1)
     objective_elements (1.1.2)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
     public_suffix (4.0.7)
+    rack (2.2.6.2)
+    rack-protection (3.0.5)
+      rack
     rainbow (3.1.1)
     rb-fsevent (0.11.1)
     rb-inotify (0.10.1)
@@ -79,20 +89,35 @@ GEM
     rouge (3.29.0)
     ruby-vips (2.0.17)
       ffi (~> 1.9)
+    ruby2_keywords (0.0.5)
     safe_yaml (1.0.5)
     sassc (2.4.0)
       ffi (~> 1.9)
+    sinatra (3.0.5)
+      mustermann (~> 3.0)
+      rack (~> 2.2, >= 2.2.4)
+      rack-protection (= 3.0.5)
+      tilt (~> 2.0)
+    sinatra-contrib (3.0.5)
+      multi_json
+      mustermann (~> 3.0)
+      rack-protection (= 3.0.5)
+      sinatra (= 3.0.5)
+      tilt (~> 2.0)
     terminal-table (2.0.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
+    tilt (2.0.11)
     unicode-display_width (1.8.0)
     webrick (1.7.0)
 
 PLATFORMS
+  universal-darwin-21
   x86_64-darwin-20
   x86_64-linux
 
 DEPENDENCIES
   bundler
+  jekyll-admin
   jekyll-feed
   jekyll-seo-tag
   jekyll-sitemap

--- a/_config.yml
+++ b/_config.yml
@@ -65,3 +65,8 @@ picture:
   source: "assets"
   output: "assets/generated"
   suppress_warnings: true
+
+jekyll_admin:
+  hidden_links:
+    - datafiles
+    - configuration


### PR DESCRIPTION
This is an example of the Jekyll Admin, it is not intended for production use on the Dovetail website.

This is easy to install.

To run the demo:
- [ ] `bundle install`
- [ ] `bundle exec jekyll server`
- [ ] Go to `localhost:4000/admin` and look around. 

Notes:
- All the files are edited in markdown. There's a WYSIWYG to help with syntax.
- Authentication in a production build would need [these settings applied](https://jekyll.github.io/jekyll-admin/self-hosting)
- This is a very simple admin interface. But its low touch, low maintenance. 