### PR TITLE
Fix Safari header

### DIFF
--- a/_sass/_show-tiles.scss
+++ b/_sass/_show-tiles.scss
@@ -107,9 +107,9 @@ $show-tile--animation-duration--step: $show-tile--animation-duration / ($show-ti
 
 @keyframes show-tile--slide-y {
   from {
-    translate: 0 -100%;
+    transform: translate(0, -100%);
   }
   to {
-    translate: 0 (($show-tiles--rows - 1) * 100%);
+    transform: translate(0, calc((#{$show-tiles--rows} - 1) * 100%));
   }
 }

--- a/_sass/layout.scss
+++ b/_sass/layout.scss
@@ -78,12 +78,13 @@ img {
 }
 
 .top {
-  padding: 50px 0 0 0;
+  padding: 0;
   margin: 0;
   min-height: 80vh;
 
   h1 {
     line-height: 1.35;
+    padding-top: 50px;
   }
 }
 


### PR DESCRIPTION
Apparently Safari desktop struggles with the transform property. This fixes it.

before:
<img width="1383" height="866" alt="Screenshot 2025-10-14 at 3 42 25 PM" src="https://github.com/user-attachments/assets/e6aeb901-b5d0-46c5-94aa-79c0d05ce745" />

after:
<img width="1381" height="870" alt="Screenshot 2025-10-14 at 3 42 17 PM" src="https://github.com/user-attachments/assets/de715010-03ed-4fcc-8caa-3b44202fae1c" />

Load up app (see readme) and open homepage in Safari.